### PR TITLE
Support of unstrict logux action matcher

### DIFF
--- a/lib/logux/test/helpers.rb
+++ b/lib/logux/test/helpers.rb
@@ -24,6 +24,11 @@ module Logux
       end
       alias a_logux_meta a_logux_meta_with
 
+      def a_logux_action_with(attributes = {})
+        RSpec::Matchers::BuiltIn::Include.new(attributes.stringify_keys)
+      end
+      alias a_logux_action a_logux_action_with
+
       def logux_approved(meta = nil)
         Logux::Test::Matchers::ResponseChunks.new(
           meta: meta, includes: ['approved'], excludes: %w[forbidden error]

--- a/spec/logux_spec.rb
+++ b/spec/logux_spec.rb
@@ -18,7 +18,7 @@ describe Logux, timecop: true do
 
     it 'sends action with meta' do
       expect { described_class.add(action) }.to send_to_logux(
-        ['action', { type: 'action' }, a_logux_meta]
+        ['action', a_logux_action_with(type: 'action'), a_logux_meta]
       )
     end
   end
@@ -41,8 +41,8 @@ describe Logux, timecop: true do
 
     it 'sends action with meta' do
       expect { described_class.add_batch(commands) }.to send_to_logux(
-        ['action', { type: 'action' }, a_logux_meta],
-        ['action', { type: 'action2' }, a_logux_meta]
+        ['action', a_logux_action_with(type: 'action'), a_logux_meta],
+        ['action', a_logux_action_with(type: 'action2'), a_logux_meta]
       )
     end
   end


### PR DESCRIPTION
For using the rspec `a_kind_of` matchers without checking the strict equvalence:
```ruby
      expect { service.update! }.to send_to_logux(
        [
          'action',
          a_logux_action(
            type: 'amplifr/prices/set',
            vanityDomainPrice: 10,
            socialPrice: a_kind_of(Numeric),
            exchange: a_kind_of(Numeric)
          ),
          a_logux_meta(channels: ['prices'])
        ]
      )
```