### PR TITLE
Add Channel#since_time syntax sugar

### DIFF
--- a/lib/logux/channel_controller.rb
+++ b/lib/logux/channel_controller.rb
@@ -15,7 +15,7 @@ module Logux
     end
 
     def since_time
-      action.dig('since', 'time')
+      action['since'].try(:[], 'time')
     end
   end
 end

--- a/lib/logux/channel_controller.rb
+++ b/lib/logux/channel_controller.rb
@@ -15,7 +15,8 @@ module Logux
     end
 
     def since_time
-      action['since'].try(:[], 'time')
+      since = action['since'].try(:[], 'time')
+      Time.at(since).to_datetime if since
     end
   end
 end

--- a/lib/logux/channel_controller.rb
+++ b/lib/logux/channel_controller.rb
@@ -15,8 +15,10 @@ module Logux
     end
 
     def since_time
-      since = action['since'].try(:[], 'time')
-      Time.at(since).to_datetime if since
+      @since_time ||= begin
+        since = action['since'].try(:[], 'time')
+        Time.at(since).to_datetime if since
+      end
     end
   end
 end

--- a/lib/logux/channel_controller.rb
+++ b/lib/logux/channel_controller.rb
@@ -13,5 +13,9 @@ module Logux
     def initial_meta
       { clients: [meta.client_id] }
     end
+
+    def since_time
+      action.dig('since', 'time')
+    end
   end
 end

--- a/spec/factories/logux_actions_factory.rb
+++ b/spec/factories/logux_actions_factory.rb
@@ -9,6 +9,17 @@ FactoryBot.define do
       end
     end
 
+    factory :logux_actions_subscribe_since do
+      skip_create
+      initialize_with do
+        new({
+          type: 'logux/subscribe',
+          channel: 'user/1',
+          since: { time: 100 }
+        }.merge(attributes))
+      end
+    end
+
     factory :logux_actions_add do
       skip_create
       initialize_with do

--- a/spec/logux/channel_controller_spec.rb
+++ b/spec/logux/channel_controller_spec.rb
@@ -11,16 +11,34 @@ describe Logux::ChannelController do
     end
   end
   let(:channel_controller) { controller_class.new(action: action, meta: meta) }
-  let(:action) { create(:logux_actions_subscribe) }
   let(:user) { User.find_or_create_by(id: 1, name: 'test') }
   let(:meta) { Logux::Meta.new }
 
   describe '#subscribe' do
+    let(:action) { create(:logux_actions_subscribe) }
     subject(:subscribe) { channel_controller.subscribe }
 
     context 'when ActiveRecord defined' do
       it 'tries to find record by chanel data' do
         expect { subscribe }.to send_to_logux(['action', { type: 'action' }])
+      end
+    end
+  end
+
+  describe '#since_time' do
+    subject(:since_time) { channel_controller.since_time }
+
+    context 'when action.since defined' do
+      let(:action) { create(:logux_actions_subscribe_since) }
+      it 'tries to find record by chanel data' do
+        expect(since_time).to eql(100)
+      end
+    end
+
+    context 'when action.since not defined' do
+      let(:action) { create(:logux_actions_subscribe) }
+      it 'tries to find record by chanel data' do
+        expect(since_time).to be_nil
       end
     end
   end

--- a/spec/logux/channel_controller_spec.rb
+++ b/spec/logux/channel_controller_spec.rb
@@ -33,7 +33,7 @@ describe Logux::ChannelController do
       let(:action) { create(:logux_actions_subscribe_since) }
 
       it 'tries to find record by chanel data' do
-        expect(since_time).to be(100)
+        expect(since_time).to eql(Time.at(100).to_datetime)
       end
     end
 

--- a/spec/logux/channel_controller_spec.rb
+++ b/spec/logux/channel_controller_spec.rb
@@ -15,8 +15,9 @@ describe Logux::ChannelController do
   let(:meta) { Logux::Meta.new }
 
   describe '#subscribe' do
-    let(:action) { create(:logux_actions_subscribe) }
     subject(:subscribe) { channel_controller.subscribe }
+
+    let(:action) { create(:logux_actions_subscribe) }
 
     context 'when ActiveRecord defined' do
       it 'tries to find record by chanel data' do
@@ -30,13 +31,15 @@ describe Logux::ChannelController do
 
     context 'when action.since defined' do
       let(:action) { create(:logux_actions_subscribe_since) }
+
       it 'tries to find record by chanel data' do
-        expect(since_time).to eql(100)
+        expect(since_time).to be(100)
       end
     end
 
     context 'when action.since not defined' do
       let(:action) { create(:logux_actions_subscribe) }
+
       it 'tries to find record by chanel data' do
         expect(since_time).to be_nil
       end


### PR DESCRIPTION
@dsalahutdinov Logux Client now send `action.since = { id, time }` on resubscription. It is useful to avoid sending unnecessary data on resubscription (now we send all notices on every connection, with this feature we will be able to send only notices created during client offline).

`action.since` contains `{ id, time }` for high precision time compare. It is a rare feature, `action.since.time` will be enough for most of the cases. 