### PR TITLE
Allow extra data to undo action

### DIFF
--- a/lib/logux.rb
+++ b/lib/logux.rb
@@ -75,9 +75,9 @@ module Logux
     Logux::Add.new.call(commands)
   end
 
-  def self.undo(meta, reason: nil)
+  def self.undo(meta, reason: nil, data: {})
     add(
-      { type: 'logux/undo', id: meta.id, reason: reason },
+      data.merge(type: 'logux/undo', id: meta.id, reason: reason),
       Logux::Meta.new(clients: [meta.client_id])
     )
   end

--- a/spec/logux_spec.rb
+++ b/spec/logux_spec.rb
@@ -56,7 +56,6 @@ describe Logux, timecop: true do
   end
 
   describe '.undo' do
-    let(:request) { described_class.undo(meta, reason: reason) }
     let(:meta) do
       Logux::Meta.new(
         id: '1 1:client:uuid 0',
@@ -67,16 +66,44 @@ describe Logux, timecop: true do
       )
     end
     let(:reason) { 'error' }
-    let(:logux_commands) do
-      [
-        'action',
-        { type: 'logux/undo', id: meta.id, reason: reason },
-        a_logux_meta_with(clients: ['1:client'])
-      ]
+
+    context 'when extra data is not provided' do
+      let(:request) { described_class.undo(meta, reason: reason) }
+      let(:logux_commands) do
+        [
+          'action',
+          { type: 'logux/undo', id: meta.id, reason: reason },
+          a_logux_meta_with(clients: ['1:client'])
+        ]
+      end
+
+      it 'makes request' do
+        expect { request }.to send_to_logux(logux_commands)
+      end
     end
 
-    it 'makes request' do
-      expect { request }.to send_to_logux(logux_commands)
+    context 'when data provided' do
+      let(:request) do
+        described_class.undo(meta,
+                             reason: reason,
+                             data: { errors: ['limitExceeded'] })
+      end
+      let(:logux_commands) do
+        [
+          'action',
+          {
+            type: 'logux/undo',
+            id: meta.id,
+            reason: reason,
+            errors: ['limitExceeded']
+          },
+          a_logux_meta_with(clients: ['1:client'])
+        ]
+      end
+
+      it 'makes request' do
+        expect { request }.to send_to_logux(logux_commands)
+      end
     end
   end
 end


### PR DESCRIPTION
Adds data parameter to the `logux/undo` command to allow to pass additional data