### PR TITLE
Fix undo meta tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: require
+install: skip
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
+language: minimal
 sudo: require
-install: skip
 services:
   - docker
 

--- a/lib/logux.rb
+++ b/lib/logux.rb
@@ -78,7 +78,7 @@ module Logux
   def self.undo(meta, reason: nil, data: {})
     add(
       data.merge(type: 'logux/undo', id: meta.id, reason: reason),
-      Logux::Meta.new(clients: [meta.client_id])
+      meta.undo_meta
     )
   end
 

--- a/lib/logux/meta.rb
+++ b/lib/logux/meta.rb
@@ -44,7 +44,7 @@ module Logux
       nodes
       reasons
       channels
-    ]
+    ].freeze
 
     private_constant :RESEND_KEYS
 

--- a/lib/logux/meta.rb
+++ b/lib/logux/meta.rb
@@ -32,5 +32,31 @@ module Logux
     def id
       fetch('id')
     end
+
+    def undo_meta
+      self.class.new(undo_meta_hash)
+    end
+
+    private
+
+    RESEND_KEYS = %w[
+      users
+      nodes
+      reasons
+      channels
+    ]
+
+    private_constant :RESEND_KEYS
+
+    def undo_meta_hash
+      { status: 'processed' }
+        .merge(slice(*RESEND_KEYS))
+        .merge(clients: clients)
+    end
+
+    def clients
+      result = [client_id]
+      key?('clients') ? (result + self['clients']) : result
+    end
   end
 end

--- a/logux_rails.gemspec
+++ b/logux_rails.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rails', '>= 5.0', '< 6.1'
   spec.add_dependency 'rest-client'
   spec.add_development_dependency 'appraisal', '~> 2.2'
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'combustion', '~> 1.1.0'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'factory_bot'

--- a/spec/logux/meta_spec.rb
+++ b/spec/logux/meta_spec.rb
@@ -84,4 +84,38 @@ describe Logux::Meta do
       end
     end
   end
+
+  describe '#undo_meta' do
+    subject(:undo_meta) { meta.undo_meta }
+
+    context 'with resend keys' do
+      let(:attributes) do
+        {
+          'users' => %w[user],
+          'nodes' => %w[node],
+          'reasons' => %w[reason],
+          'channels' => %w[channel]
+        }
+      end
+
+      it 'copies re-send keys' do
+        expect(undo_meta).to include(attributes)
+      end
+    end
+
+    context 'with clients list' do
+      let(:clients_list) { %w[client] }
+      let(:attributes) { { 'clients' => clients_list } }
+
+      it 'appends client ids' do
+        expect(undo_meta['clients']).to eq([meta.client_id] + clients_list)
+      end
+    end
+
+    context 'without clients list' do
+      it 'contains client id' do
+        expect(undo_meta['clients']).to eq([meta.client_id])
+      end
+    end
+  end
 end


### PR DESCRIPTION
This patch updates meta for the `undo` command, following the [reference implementation](https://github.com/logux/server/blob/master/base-server.js#L676-L682).

References:

- Original issue: https://github.com/logux/logux_rails/issues/73
- [Reference JS implementation](https://github.com/logux/server/blob/master/base-server.js#L676-L682)
- [Reference spec](https://github.com/logux/server/blob/master/test/base-server.test.js#L615)
- [Logux actions spec](https://github.com/logux/logux/blob/f643d847a8d1b2c439b292c15a1e6d2bbb7332a3/3-concepts/2-action.md)