### PR TITLE
Relax Rails dependency constraint

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -15,3 +15,7 @@ end
 appraise '6.0' do
   gem 'activerecord', '~> 6.0'
 end
+
+appraise '6.1' do
+  gem 'activerecord', '~> 6.1'
+end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.0.0
+
+* Support Rails 6.1.
+* Support Logux protocol v3 (breaking change, Logux.config.password is renamed to Logux.config.secret).
+
 ## 0.2
 * Core Logux facilities are moved to `logux-rack` gem.
 * `Logux::Actions` is soft-deprecated. Please use `Logux::Action` from now on.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - DB_HOST=db
       - DB_NAME=logux_rails
       - DB_USERNAME=postgres
+      - DB_PASSWORD=password
     command: bash
     working_dir: /app
     volumes:
@@ -24,6 +25,7 @@ services:
     image: postgres:10
     environment:
       - POSTGRES_DB=logux_rails
+      - POSTGRES_PASSWORD=password
 
 volumes:
   bundler_data:

--- a/lib/logux/version.rb
+++ b/lib/logux/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Logux
-  VERSION = '0.2.0'
+  VERSION = '1.0.0'
 end

--- a/logux_rails.gemspec
+++ b/logux_rails.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'logux-rack', '>= 0.1.0'
-  spec.add_dependency 'rails', '>= 5.0', '< 6.1'
+  spec.add_dependency 'rails', '>= 5.0'
   spec.add_development_dependency 'appraisal', '~> 2.2'
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'combustion', '~> 1.1.0'

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -3,3 +3,4 @@ test:
   host: <%= ENV.fetch("DB_HOST") %>
   database: <%= ENV.fetch("DB_NAME") %>
   username: <%= ENV.fetch("DB_USERNAME") %>
+  password: <%= ENV.fetch("DB_PASSWORD") %>

--- a/spec/requests/request_logux_server_spec.rb
+++ b/spec/requests/request_logux_server_spec.rb
@@ -9,11 +9,11 @@ describe 'Request logux server' do
          as: :json)
   end
 
-  let(:password) { Logux.configuration.password }
+  let(:secret) { Logux.configuration.secret }
 
   let(:logux_params) do
     { version: Logux::PROTOCOL_VERSION,
-      password: password,
+      secret: secret,
       commands: [
         ['action',
          { type: 'logux/subscribe', channel: 'post/123' },
@@ -41,7 +41,7 @@ describe 'Request logux server' do
 
     let(:logux_params) do
       { version: Logux::PROTOCOL_VERSION,
-        password: password,
+        secret: secret,
         commands: [
           ['action',
            { type: 'comment/update', key: 'text', value: 'hi' },
@@ -54,7 +54,7 @@ describe 'Request logux server' do
     end
   end
 
-  context 'when password wrong' do
+  context 'when secret wrong' do
     before { request_logux }
 
     let(:password) { '12345' }
@@ -67,7 +67,7 @@ describe 'Request logux server' do
   context 'with proxy' do
     let(:logux_params) do
       { version: Logux::PROTOCOL_VERSION,
-        password: password,
+        secret: secret,
         commands: [
           ['action',
            { type: 'logux/subscribe', channel: 'post/123' },

--- a/spec/requests/request_logux_server_spec.rb
+++ b/spec/requests/request_logux_server_spec.rb
@@ -60,7 +60,7 @@ describe 'Request logux server' do
     let(:secret) { 'INTENTIONALLY_WRONG' }
 
     it 'returns error' do
-      expect(response).to be_forbidden?
+      expect(response).to be_forbidden
     end
   end
 

--- a/spec/requests/request_logux_server_spec.rb
+++ b/spec/requests/request_logux_server_spec.rb
@@ -57,10 +57,10 @@ describe 'Request logux server' do
   context 'when secret wrong' do
     before { request_logux }
 
-    let(:password) { '12345' }
+    let(:secret) { 'INTENTIONALLY_WRONG' }
 
     it 'returns error' do
-      expect(response).to logux_unauthorized
+      expect(response).to be_forbidden?
     end
   end
 

--- a/spec/requests/request_without_action_spec.rb
+++ b/spec/requests/request_without_action_spec.rb
@@ -9,11 +9,11 @@ describe 'Request logux server without action' do
          as: :json)
   end
 
-  let(:password) { Logux.configuration.password }
+  let(:secret) { Logux.configuration.secret }
 
   let(:logux_params) do
     { version: Logux::PROTOCOL_VERSION,
-      password: password,
+      secret: secret,
       commands: [
         ['action',
          { type: action, key: 'text', value: 'hi' },

--- a/spec/requests/request_without_subscribe_spec.rb
+++ b/spec/requests/request_without_subscribe_spec.rb
@@ -9,11 +9,11 @@ describe 'Request logux server without subscribe' do
          as: :json)
   end
 
-  let(:password) { Logux.configuration.password }
+  let(:secret) { Logux.configuration.secret }
 
   let(:logux_params) do
     { version: Logux::PROTOCOL_VERSION,
-      password: password,
+      secret: secret,
       commands: [
         ['action',
          { type: 'logux/subscribe', channel: channel },


### PR DESCRIPTION
Motivation:

- Support Rails 6.1+.

Changes:

- Use native RSpec matcher to test a response error instead of logux_unauthorized that disappeared somehow.
- Use explicit PostreSQL password to prevent development environment setup error.
- Bump gem version to 1.0.0. Major version since Logux introduce a breaking change replacing `password` setting with `secret` (see https://github.com/logux/logux-rack/commit/58e9a7f8630f59d782981868835a66a111e71f4f).
- Replace deprecated Rails methods for 6.1 compatibility.

References:

- https://github.com/logux/logux-rack/pull/11